### PR TITLE
32/add verbosity switch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 coverage
 rdoc
 pkg
+Gemfile.lock

--- a/README.textile
+++ b/README.textile
@@ -296,6 +296,13 @@ should "generate right sized array" do
 end
 </code></pre>
 
+If you wish to have quiet output from Rantly, set environmental variable:
+<pre><code>
+RANTLY_VERBOSE=0 # silent
+RANTLY_VERBOSE=1 # verbose and default if env is not set
+</code></pre>
+This will silence the puts, print, and pretty_print statements in property.rb.
+
 That's about it. Enjoy :)
 
 

--- a/lib/rantly/generator.rb
+++ b/lib/rantly/generator.rb
@@ -223,10 +223,7 @@ class Rantly
   module Chars
 
     class << self
-      ASCII = ""
-      (0..127).to_a.each do |i|
-        ASCII << i
-      end
+      ASCII = (0..127).to_a.each_with_object("") { |i, obj| obj << i }
 
       def of(regexp)
         ASCII.scan(regexp).to_a.map! { |char| char[0].ord }

--- a/lib/rantly/generator.rb
+++ b/lib/rantly/generator.rb
@@ -22,7 +22,7 @@ class Rantly
     def value(limit=10,&block)
       gen.value(limit,&block)
     end
-    
+
     def gen
       self.singleton
     end
@@ -32,7 +32,6 @@ class Rantly
   end
 
   class TooManyTries < RuntimeError
-    
     def initialize(limit,nfailed)
       @limit = limit
       @nfailed = nfailed
@@ -84,7 +83,7 @@ class Rantly
       handler.call(val) if handler
     end
   end
-  
+
   attr_accessor :classifiers
 
   def initialize
@@ -111,7 +110,7 @@ class Rantly
   def size
     @size || Rantly.default_size
   end
-  
+
   def sized(n,&block)
     raise "size needs to be greater than zero" if n < 0
     old_size = @size
@@ -222,7 +221,7 @@ class Rantly
   end
 
   module Chars
-    
+
     class << self
       ASCII = ""
       (0..127).to_a.each do |i|
@@ -233,7 +232,7 @@ class Rantly
         ASCII.scan(regexp).to_a.map! { |char| char[0].ord }
       end
     end
-    
+
     ALNUM = Chars.of /[[:alnum:]]/
     ALPHA = Chars.of /[[:alpha:]]/
     BLANK = Chars.of /[[:blank:]]/
@@ -247,8 +246,8 @@ class Rantly
     UPPER = Chars.of /[[:upper:]]/
     XDIGIT = Chars.of /[[:xdigit:]]/
     ASCII = Chars.of /./
-    
-    
+
+
     CLASSES = {
       :alnum => ALNUM,
       :alpha => ALPHA,
@@ -264,7 +263,7 @@ class Rantly
       :xdigit => XDIGIT,
       :ascii => ASCII,
     }
-    
+
   end
 
   def string(char_class=:print)

--- a/lib/rantly/silly.rb
+++ b/lib/rantly/silly.rb
@@ -21,7 +21,7 @@ module Rantly::Silly::Love
 #{post_script}
 EOS
   end
-  
+
   def address
     "my #{extremifier} #{pedestal_label}"
   end
@@ -60,9 +60,8 @@ EOS
   end
 
   def caused_by
-    
   end
-  
+
   def whoami
     "#{extremifier} #{humbleizer} #{groveler}"
   end
@@ -113,4 +112,3 @@ EOS
     choose "once in a while","night","day","hour","minute"
   end
 end
-

--- a/test/rantly_test.rb
+++ b/test/rantly_test.rb
@@ -10,7 +10,7 @@ class RantlyTest::Generator < Test::Unit::TestCase
   def setup
     Rantly.gen.reset
   end
-  
+
   should "fail test generation" do
     assert_raises(Rantly::TooManyTries) {
       property_of { guard range(0,1) < 0 }.check
@@ -37,7 +37,7 @@ class RantlyTest::Generator < Test::Unit::TestCase
       lo, hi = [integer(100),integer(100)].sort
       [lo,hi,range(lo,hi)]
     }.check { |(lo,hi,int)|
-      assert((lo..hi).include?(int)) 
+      assert((lo..hi).include?(int))
     }
   end
 
@@ -128,7 +128,7 @@ class RantlyTest::Generator < Test::Unit::TestCase
       assert_equal a, b
     }
   end
-  
+
   should "call Proc with generator.instance_eval" do
     property_of {
       call Proc.new { true }
@@ -147,7 +147,7 @@ class RantlyTest::Generator < Test::Unit::TestCase
       assert i1 > i0
     }
   end
-  
+
   should "raise if calling on any other value" do
     assert_raise(RuntimeError) {
       Rantly.gen.call 0
@@ -169,9 +169,8 @@ class RantlyTest::Generator < Test::Unit::TestCase
     }
   end
 
-  
   # choose
-  
+
   should "choose a value from args " do
     property_of {
       choose
@@ -190,7 +189,7 @@ class RantlyTest::Generator < Test::Unit::TestCase
     }
     property_of {
       arr = sized(10) { array { integer } }
-      choose(*arr) 
+      choose(*arr)
     }.check { |o|
       assert o.is_a?(Fixnum)
     }
@@ -240,7 +239,7 @@ class RantlyTest::Generator < Test::Unit::TestCase
       assert o.empty?
     }
   end
-  
+
   should "generate the right sized nested arrays" do
     property_of {
       size1 = range(5,10)
@@ -252,7 +251,7 @@ class RantlyTest::Generator < Test::Unit::TestCase
       assert outter_array.all? { |inner_array| inner_array.size < size1 }
     }
   end
-  
+
   should "generate array with right types" do
     property_of {
       sized(10) { array { freq(:integer,:string,:float)}  }
@@ -275,10 +274,9 @@ class RantlyTest::Generator < Test::Unit::TestCase
 #   end
 
 end
-  
+
 
 
 # TODO: check that distributions of different methods look roughly correct.
 class RantlyTest::Distribution
-  
 end

--- a/test/shrinks_test.rb
+++ b/test/shrinks_test.rb
@@ -97,7 +97,7 @@ class RantlyTest::Shrinkers::Test < Test::Unit::TestCase
         assert(!a.any? { |e| e > 0 } && a.length < 4,"contains 1")
       }
     end
-    
-    assert_equal [0,0,0,0], test.shrunk_failed_data 
+
+    assert_equal [0,0,0,0], test.shrunk_failed_data
   end
 end


### PR DESCRIPTION
Adds verbosity environmental variable to silence output

[Fixes #32]

Thanks for writing this gem :)! I'm looking forward to using it as I branch out 
into more generative testing.

PR can be utilized as follows:

Use RANTLY_VERBOSE=0 to silence output during tests.
Use RANTLY_VERBOSE=1 (default value if env isn't set) to display output during tests.

Allows users to silence output, if they wish.

PS - sorry the trailing whitespace commits ended up in this PR. I meant to submit them separately. If you'd like me to split them out, please let me know :smile_cat:.
